### PR TITLE
Fix tree walker call

### DIFF
--- a/src/utils/__tests__/manifestGenerator.test.ts
+++ b/src/utils/__tests__/manifestGenerator.test.ts
@@ -20,18 +20,32 @@ Object.defineProperty(global, 'DOMParser', {
           textContent: content.replace(/<[^>]*>/g, ''), // Strip HTML tags
           querySelectorAll: () => [],
           hasAttribute: () => false
+        },
+        createTreeWalker: () => {
+          let used = false
+          return {
+            nextNode: () => {
+              if (used || !content) return null
+              used = true
+              return {
+                nodeType: Node.TEXT_NODE,
+                textContent: content,
+                parentElement: { hasAttribute: () => false }
+              }
+            }
+          }
         }
       }
     }
   }
 })
 
-Object.defineProperty(global, 'document', {
-  value: {
-    createTreeWalker: () => ({
-      nextNode: () => null
-    })
-  }
+Object.defineProperty(global, 'NodeFilter', {
+  value: { SHOW_ALL: 0 }
+})
+
+Object.defineProperty(global, 'Node', {
+  value: { ELEMENT_NODE: 1, TEXT_NODE: 3 }
 })
 
 // Mock crypto.subtle for Node.js environment
@@ -39,10 +53,11 @@ Object.defineProperty(global, 'crypto', {
   value: {
     subtle: {
       digest: async (_algorithm: string, data: ArrayBuffer) => {
-        // Simple mock hash - in production use real crypto
+        // Use Node's crypto module to generate a deterministic hash
+        const { createHash } = require('crypto')
         const text = new TextDecoder().decode(data)
-        const hash = Buffer.from(text).toString('hex').substring(0, 64)
-        return Buffer.from(hash, 'hex').buffer
+        const buf = createHash('sha256').update(text).digest()
+        return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
       }
     }
   }

--- a/src/utils/manifestGenerator.ts
+++ b/src/utils/manifestGenerator.ts
@@ -36,7 +36,7 @@ export function calculateProvenanceFromText(content: string): ProvenanceStats {
   let citedChars = 0
   
   // Walk through all text nodes and their provenance marks
-  const walker = document.createTreeWalker(
+  const walker = doc.createTreeWalker(
     doc.body,
     NodeFilter.SHOW_ALL,
     null


### PR DESCRIPTION
## Summary
- use `doc.createTreeWalker` in `calculateProvenanceFromText`
- update DOM mocks for new API usage
- adjust crypto mock to use Node's hashing

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ebda30acc8321af34d9f566d63a70