### PR TITLE
Fix manifest API naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ else human_tokens += span_length;
   "public_key": "ed25519:MCowBQYDK2VwAyEA..."
 }
 ```
+### Programmatic Manifest Generation
+
+```typescript
+import { generateCompleteManifest } from "./src/utils/manifestGenerator"
+
+const manifest = await generateCompleteManifest(html, events)
+console.log(manifest)
+```
+
 
 ## 🛡️ Verification
 

--- a/src/utils/__tests__/manifestGenerator.test.ts
+++ b/src/utils/__tests__/manifestGenerator.test.ts
@@ -11,13 +11,15 @@ import {
 import type { ProvenanceEvent, ManifestData } from '../manifestGenerator'
 
 // Mock DOM APIs for testing
+// Minimal DOM parser and tree walker stubs
+let lastContent = ''
 Object.defineProperty(global, 'DOMParser', {
   value: class MockDOMParser {
     parseFromString(content: string, _mimeType: string) {
-      // Simple mock - in real tests you'd use jsdom
+      lastContent = content.replace(/<[^>]*>/g, '')
       return {
         body: {
-          textContent: content.replace(/<[^>]*>/g, ''), // Strip HTML tags
+          textContent: lastContent,
           querySelectorAll: () => [],
           hasAttribute: () => false
         }
@@ -28,10 +30,30 @@ Object.defineProperty(global, 'DOMParser', {
 
 Object.defineProperty(global, 'document', {
   value: {
-    createTreeWalker: () => ({
-      nextNode: () => null
-    })
+    createTreeWalker: () => {
+      let done = false
+      return {
+        nextNode: () => {
+          if (done) return null
+          done = true
+          return {
+            nodeType: Node.TEXT_NODE,
+            textContent: lastContent,
+            parentElement: null
+          }
+        }
+      }
+    }
   }
+})
+
+// Provide NodeFilter constant for createTreeWalker options
+Object.defineProperty(global, 'NodeFilter', {
+  value: { SHOW_ALL: 0xFFFFFFFF }
+})
+
+Object.defineProperty(global, 'Node', {
+  value: { ELEMENT_NODE: 1, TEXT_NODE: 3 }
 })
 
 // Mock crypto.subtle for Node.js environment
@@ -39,10 +61,10 @@ Object.defineProperty(global, 'crypto', {
   value: {
     subtle: {
       digest: async (_algorithm: string, data: ArrayBuffer) => {
-        // Simple mock hash - in production use real crypto
-        const text = new TextDecoder().decode(data)
-        const hash = Buffer.from(text).toString('hex').substring(0, 64)
-        return Buffer.from(hash, 'hex').buffer
+        // Use Node's crypto module to generate a stable hash
+        const { createHash } = await import('crypto')
+        const buffer = Buffer.from(new Uint8Array(data))
+        return createHash('sha256').update(buffer).digest().buffer
       }
     }
   }


### PR DESCRIPTION
## Summary
- set `generateCompleteManifest` as canonical API name
- sync the implementation guide with the correct function name
- document programmatic manifest generation in README
- fix Node environment test stubs so `npm test` passes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ebdd571308321893468d39488e113